### PR TITLE
Adjust set(..) and get(..) in UnsafeBitArray.scala such that all bits are potentially used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ bf.add(element)
 // Check whether an element in a set
 bf.mightContain(element)
 
+// Serialize
+val bytes:Array[Byte] = bf.serialize()
+println(s"Dump: ${bytes.map("%02X " format _).mkString.dropRight(1)}")
+
 // Dispose the instance
 bf.dispose()
 ```

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ bf.add(element)
 // Check whether an element in a set
 bf.mightContain(element)
 
-// Serialize
+// (De)serialize
 val bytes:Array[Byte] = bf.serialize()
-println(s"Dump: ${bytes.map("%02X " format _).mkString.dropRight(1)}")
+val newBf = BloomFilter[String](expectedElements, falsePositiveRate)
+newBf.restoreArray(bytes)
 
 // Dispose the instance
 bf.dispose()

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/BloomFilter.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/BloomFilter.scala
@@ -56,6 +56,8 @@ class BloomFilter[T] private (val numberOfBits: Long, val numberOfHashes: Int, p
 
   def serialize(): Array[Byte] = bits.dump()
 
+  def restoreArray(a: Array[Byte]): Unit = bits.setArray(a)
+
 }
 
 object BloomFilter {

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/BloomFilter.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/BloomFilter.scala
@@ -54,6 +54,8 @@ class BloomFilter[T] private (val numberOfBits: Long, val numberOfHashes: Int, p
 
   def dispose(): Unit = bits.dispose()
 
+  def serialize(): Array[Byte] = bits.dump()
+
 }
 
 object BloomFilter {

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
@@ -8,11 +8,11 @@ class UnsafeBitArray(val numberOfBits: Long) {
   unsafe.setMemory(ptr, 8L*indices, 0.toByte)
 
   def get(index: Long): Boolean = {
-    (unsafe.getLong(ptr + (index >>> 6)) & (1L << index)) != 0
+    (unsafe.getLong(ptr + (index >>> 6)*8L) & (1L << index)) != 0
   }
 
   def set(index: Long): Unit = {
-    val offset = ptr + (index >>> 6)
+    val offset = ptr + (index >>> 6) * 8L
     val long = unsafe.getLong(offset)
     unsafe.putLong(offset, long | (1L << index))
   }

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
@@ -51,4 +51,12 @@ class UnsafeBitArray(val numberOfBits: Long) {
     bytes
   }
 
+  def setArray(a:Array[Byte]) = {
+    assert(a.length == indices*8L, "array length mismatch")
+    for (index <- 0L to indices*8L-1L) {
+      val current = unsafe.getByte(ptr+index)
+      unsafe.putByte(ptr+index, (current | a(index.toInt)).toByte)
+    }
+  }
+
 }

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
@@ -39,4 +39,16 @@ class UnsafeBitArray(val numberOfBits: Long) {
   }
 
   def dispose(): Unit = unsafe.freeMemory(ptr)
+
+  def dump():Array[Byte] = {
+    val bytes:Array[Byte] = Array.fill[Byte](indices.toInt*8)(0.toByte)
+    unsafe.copyMemory(
+      null,
+      ptr,
+      bytes,
+      sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET,
+      indices*8L);
+    bytes
+  }
+
 }


### PR DESCRIPTION
(1) Adjust set(..) and get(..) in UnsafeBitArray.scala such that all bits are potentially used.

Up to now, only the first (indices+7) bytes were used. Example: If numberOfBits is 192 then indices is 3. In this case, only the first 10 of 24 bytes are potentially touched. The remaining 14 bytes stay always 0x00.

(2) Serialization/Dumping