### PR TITLE
Scala 2.12.2 support added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     jdk: oraclejdk7
   - scala: 2.11.8
     jdk: oraclejdk8
+  - scala: 2.12.2
+    jdk: oraclejdk8
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean package
 sudo: false

--- a/bloom-filter/src/main/scala/bloomfilter/CanGenerate128HashFrom.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/CanGenerate128HashFrom.scala
@@ -15,7 +15,7 @@ object CanGenerate128HashFrom {
 
   implicit case object CanGenerate128HashFromString extends CanGenerate128HashFrom[String] {
 
-    import scala.concurrent.util.Unsafe.{instance => unsafe}
+    import bloomfilter.util.Unsafe.unsafe
 
     private val valueOffset = unsafe.objectFieldOffset(classOf[String].getDeclaredField("value"))
 

--- a/bloom-filter/src/main/scala/bloomfilter/CanGenerateHashFrom.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/CanGenerateHashFrom.scala
@@ -19,7 +19,7 @@ object CanGenerateHashFrom {
 
   implicit case object CanGenerateHashFromString extends CanGenerateHashFrom[String] {
 
-    import scala.concurrent.util.Unsafe.{instance => unsafe}
+    import bloomfilter.util.Unsafe.unsafe
 
     private val valueOffset = unsafe.objectFieldOffset(classOf[String].getDeclaredField("value"))
 

--- a/bloom-filter/src/main/scala/bloomfilter/CanGetDataFrom.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/CanGetDataFrom.scala
@@ -1,6 +1,6 @@
 package bloomfilter
 
-import scala.concurrent.util.Unsafe.{instance => unsafe}
+import bloomfilter.util.Unsafe.unsafe
 
 trait CanGetDataFrom[-From] {
   def getLong(from: From, offset: Int): Long

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
@@ -2,7 +2,7 @@ package bloomfilter.mutable
 
 import java.io._
 
-import scala.concurrent.util.Unsafe.{instance => unsafe}
+import bloomfilter.util.Unsafe.unsafe
 
 @SerialVersionUID(1L)
 class UnsafeBitArray(val numberOfBits: Long) extends Serializable {

--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeTable.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeTable.scala
@@ -2,7 +2,7 @@ package bloomfilter.mutable
 
 import java.io._
 
-import scala.concurrent.util.Unsafe.{instance => unsafe}
+import bloomfilter.util.Unsafe.unsafe
 
 
 // TODO macro for various bits?

--- a/bloom-filter/src/main/scala/bloomfilter/util/Unsafe.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/util/Unsafe.scala
@@ -1,0 +1,24 @@
+package bloomfilter.util
+
+import sun.misc.{Unsafe => JUnsafe}
+
+import scala.language.postfixOps
+import scala.util.Try
+
+object Unsafe {
+  val unsafe: JUnsafe = Try {
+    classOf[JUnsafe]
+      .getDeclaredFields
+      .find { field =>
+        field.getType == classOf[JUnsafe]
+      }
+      .map { field =>
+        field.setAccessible(true)
+        field.get(null).asInstanceOf[JUnsafe]
+      }
+      .getOrElse(throw new IllegalStateException("Can't find instance of sun.misc.Unsafe"))
+  } recover {
+    case th: Throwable => throw new ExceptionInInitializerError(th)
+  } get
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt.Keys._
 import sbt._
 
 object Dependencies {
-  private val scalatest = "org.scalatest" %% "scalatest" % "2.2.6" % "test;endToEnd"
-  private val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.3" % "test"
+  private val scalatest = "org.scalatest" %% "scalatest" % "3.0.3" % "test;endToEnd"
+  private val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
   private val googleGuava = "com.google.guava" % "guava" % "19.0"
   private val googleFindbugs = "com.google.code.findbugs" % "jsr305" % "2.0.3" // needed by guava
   private val breeze = "org.scalanlp" %% "breeze" % "0.12"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -4,8 +4,8 @@ import sbt.Keys._
 object Settings {
 
   private lazy val build = Seq(
-    scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    scalaVersion := "2.12.2",
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.2"),
 
     autoCompilerPlugins := true,
 
@@ -39,13 +39,13 @@ object Settings {
       "-deprecation",
       "-encoding", "UTF-8",
       "-feature",
-      "-unchecked",
-      "-optimise"
+      "-unchecked"
     )
 
     def specificFor(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, 11)) => Seq("-target:jvm-1.8")
-      case Some((2, 10)) => Seq("-target:jvm-1.7")
+      case Some((2, 12)) => Seq("-target:jvm-1.8")
+      case Some((2, 11)) => Seq("-target:jvm-1.8", "-optimise")
+      case Some((2, 10)) => Seq("-target:jvm-1.7", "-optimise")
       case _ => Nil
     }
 

--- a/sandbox/src/main/scala/sandbox/bloomfilter/mutable/ChronicleBitArray.scala
+++ b/sandbox/src/main/scala/sandbox/bloomfilter/mutable/ChronicleBitArray.scala
@@ -2,7 +2,7 @@ package sandbox.bloomfilter.mutable
 
 import net.openhft.chronicle.bytes.NativeBytesStore
 
-import scala.concurrent.util.Unsafe.{instance => unsafe}
+import bloomfilter.util.Unsafe.unsafe
 
 class ChronicleBitArray(numberOfBits: Long) {
   private val indices = math.ceil(numberOfBits.toDouble / 64).toLong


### PR DESCRIPTION
I've had to rewrite a deprecated `scala.concurrent.util.Unsafe` class with Scala and put it into your project. By the way, It will not work on Java 9.

Also I've removed a deprecated `-optimise` flag from compiler parameters for Scala 2.12 because it would lead to compilation errors.

Besides I've updated versions of `scalatest` and `scalacheck`, because previous versions have no builds for Scala 2.12.