### PR TITLE
Fix bitCount is 0 after intersect or union

### DIFF
--- a/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/mutable/UnsafeBitArray.scala
@@ -34,10 +34,7 @@ class UnsafeBitArray(val numberOfBits: Long) extends Serializable {
       val thatLong = unsafe.getLong(that.ptr + (index >>> 6) * 8L)
       val longAtIndex = combiner(thisLong, thatLong)
       unsafe.putLong(result.ptr + (index >>> 6) * 8L, longAtIndex)
-//      result.addBitCount(UnsafeBitArray.getSetBit(longAtIndex))
-      if (longAtIndex > 0) {
-        result.addBitCount(1)
-      }
+      result.addBitCount(UnsafeBitArray.getSetBit(longAtIndex))
       index += 64
     }
     result


### PR DESCRIPTION
use the fact that after i & (i - 1), the right most of set bit of "i"
will be unset
ref: https://www.quora.com/How-do-you-count-the-number-of-1-bits-in-a-number-using-only-bitwise-operations