### PR TITLE
Fix for Issue #53

### DIFF
--- a/bloom-filter/src/main/scala/bloomfilter/CanGenerate128HashFrom.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/CanGenerate128HashFrom.scala
@@ -37,7 +37,7 @@ object CanGenerate128HashFrom {
 
     override def generateHash(from: String): (Long, Long) = {
       val value = unsafe.getObject(from, valueOffset).asInstanceOf[Array[Byte]]
-      MurmurHash3Generic.murmurhash3_x64_128(value, 0, from.length, 0)
+      MurmurHash3Generic.murmurhash3_x64_128(value, 0, value.length, 0)
     }
   }
 

--- a/bloom-filter/src/main/scala/bloomfilter/CanGenerateHashFrom.scala
+++ b/bloom-filter/src/main/scala/bloomfilter/CanGenerateHashFrom.scala
@@ -34,7 +34,7 @@ object CanGenerateHashFrom {
 
     override def generateHash(from: String): Long = {
       val value = unsafe.getObject(from, valueOffset).asInstanceOf[Array[Byte]]
-      MurmurHash3Generic.murmurhash3_x64_64(value, 0, from.length, 0)
+      MurmurHash3Generic.murmurhash3_x64_64(value, 0, value.length, 0)
     }
   }
 


### PR DESCRIPTION
Pass the size of the byte array instead of the length of the string because the length of the byte array can sometimes be 2x the length of the string, depending on which character encoding the string is stored with.